### PR TITLE
Remove MultiJson dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2
   - jruby-19mode
   - rbx-19mode
   - ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 group :test do
   gem 'rack-test'
-  gem 'rspec', '~> 2.8'
+  gem 'rspec', '~> 3.2'
   gem 'simplecov'
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in omniauth-xauth.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,15 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in omniauth-xauth.gemspec
 gemspec
 
+gem 'rake'
+
 platforms :jruby do
   gem 'jruby-openssl', '~> 0.7'
 end
 
 group :test do
-  gem 'rspec', '~> 2.8'
-  gem 'webmock'
   gem 'rack-test'
+  gem 'rspec', '~> 2.8'
+  gem 'simplecov'
+  gem 'webmock'
 end

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-![Dependency Status](https://gemnasium.com/aereal/omniauth-xauth.png)
-
-![Build Status](https://secure.travis-ci.org/aereal/omniauth-xauth.png)
-
+[![Build Status](https://travis-ci.org/aereal/omniauth-xauth.svg?branch=master)](https://travis-ci.org/aereal/omniauth-xauth)
+[![Dependency Status](https://gemnasium.com/aereal/omniauth-xauth.png)](https://gemnasium.com/aereal/omniauth-xauth)
 
 # OmniAuth XAuth
 
@@ -20,39 +18,40 @@ and can be styled as such.
 To create an OmniAuth XAuth strategy using this gem, you can simply
 subclass it and add a few extra methods like so:
 
-    require 'omniauth-xauth'
+```ruby
+require 'json'
+require 'omniauth-xauth'
 
-    module OmniAuth
-      module Strategies
-        class SomeSite < OmniAuth::Strategies::XAuth
-          option :client_options, {
-            :site               => 'http://www.service.com/',
-            :access_token_url   => 'https://www.service.com/oauth/access_token'
-          }
-          option :xauth_options, { :title => 'XAuth Login Form Header'}
+module OmniAuth
+  module Strategies
+    class SomeSite < OmniAuth::Strategies::XAuth
+      option :client_options, {
+        :site               => 'http://www.service.com/',
+        :access_token_url   => 'https://www.service.com/oauth/access_token'
+      }
+      option :xauth_options, { :title => 'XAuth Login Form Header'}
 
+      # This is where you pass the options you would pass when
+      # initializing your consumer from the OAuth gem.
 
-          # This is where you pass the options you would pass when
-          # initializing your consumer from the OAuth gem.
+      uid { raw_info['uid'] }
+      info do
+        {
+          :name => raw_info['name'],
+          :email => raw_info['email']
+        }
+      end
 
+      extra do
+        {
+          'raw_info' => raw_info
+        }
+      end
 
-          uid { raw_info['uid'] }
-          info do
-            {
-              :name => raw_info['name'],
-              :email => raw_info['email']
-            }
-          end
-
-          extra do
-            {
-              'raw_info' => raw_info
-            }
-          end
-
-          def raw_info
-            @raw_info ||= MultiJson.decode(access_token.get('/me.json').body)
-          end
-        end
+      def raw_info
+        @raw_info ||= JSON.load(access_token.get('/me.json').body)
       end
     end
+  end
+end
+```

--- a/lib/omniauth/strategies/xauth.rb
+++ b/lib/omniauth/strategies/xauth.rb
@@ -1,5 +1,4 @@
 require 'omniauth'
-require 'multi_json'
 require 'oauth'
 
 module OmniAuth
@@ -48,8 +47,6 @@ module OmniAuth
         fail!(:service_unavailable, e)
       rescue ::OAuth::Unauthorized => e
         fail!(:invalid_credentials, e)
-      rescue ::MultiJson::DecodeError => e
-        fail!(:invalid_response, e)
       rescue ::OmniAuth::NoSessionError => e
         fail!(:session_expired, e)
       rescue => e

--- a/omniauth-xauth.gemspec
+++ b/omniauth-xauth.gemspec
@@ -7,20 +7,14 @@ Gem::Specification.new do |s|
   s.authors     = ["aereal"]
   s.email       = ["aereal@kerare.org"]
   s.homepage    = "https://github.com/aereal/omniauth-xauth"
-  s.summary     = %q{Abstract XAuth strategy for OmniAuth}
   s.description = %q{Abstract XAuth strategy for OmniAuth}
-
-  s.rubyforge_project = "omniauth-xauth"
+  s.summary     = s.description
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency     'omniauth', '~> 1.0'
-  s.add_runtime_dependency     'oauth'
-  s.add_development_dependency 'rspec', '~> 2.8'
-  s.add_development_dependency 'webmock'
-  s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'rack-test'
+  s.add_dependency 'omniauth', '~> 1.0'
+  s.add_dependency 'oauth'
 end

--- a/spec/omniauth/strategies/xauth_spec.rb
+++ b/spec/omniauth/strategies/xauth_spec.rb
@@ -119,19 +119,6 @@ describe "OmniAuth::Strategies::XAuth" do
         last_request.env['omniauth.error.type'] = :invalid_credentials
       end
     end
-
-    context 'JSON Parse error' do
-      before do
-        stub_request(:post, 'https://api.example.org/oauth/access_token').
-           to_raise(::MultiJson::DecodeError.new("Parse Error", 'foo', 'bar'))
-        get '/auth/example.org/callback', {}, {'rack.session' => { 'omniauth.xauth' => { 'x_auth_mode' => 'client_auth', 'x_auth_username' => 'username', 'x_auth_password' => 'password' }}}
-      end
-
-      it 'should call fail! with :service_unavailable' do
-        last_request.env['omniauth.error'].should be_kind_of(::MultiJson::DecodeError)
-        last_request.env['omniauth.error.type'] = :invalid_response
-      end
-    end
   end
 
   describe '/auth/{name}/callback with expired session' do

--- a/spec/omniauth/strategies/xauth_spec.rb
+++ b/spec/omniauth/strategies/xauth_spec.rb
@@ -108,8 +108,9 @@ describe "OmniAuth::Strategies::XAuth" do
 
     context 'Unauthorized failure' do
       before do
+        response = Struct.new(:code, :message).new(401, "Unauthorized")
         stub_request(:post, 'https://api.example.org/oauth/access_token').
-           to_raise(::OAuth::Unauthorized.new("Unauthorized"))
+           to_raise(::OAuth::Unauthorized.new(response))
         get '/auth/example.org/callback', {}, {'rack.session' => { 'omniauth.xauth' => { 'x_auth_mode' => 'client_auth', 'x_auth_username' => 'username', 'x_auth_password' => 'password' }}}
       end
 

--- a/spec/omniauth/strategies/xauth_spec.rb
+++ b/spec/omniauth/strategies/xauth_spec.rb
@@ -22,8 +22,8 @@ describe "OmniAuth::Strategies::XAuth" do
     last_request.env['rack.session']
   end
 
-  it 'should add a camelization for itself' do
-    OmniAuth::Utils.camelize('xauth').should == 'XAuth'
+  it 'adds a camelization for itself' do
+    expect(OmniAuth::Utils.camelize('xauth')).to eq('XAuth')
   end
 
   describe '/auth/{name}' do
@@ -32,10 +32,10 @@ describe "OmniAuth::Strategies::XAuth" do
         get '/auth/example.org'
       end
 
-      it 'should render an Omniauth::Form' do
-        last_response.should be_ok
-        last_response.body.should include('Username')
-        last_response.body.should include('Password')
+      it 'renders an Omniauth::Form' do
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('Username')
+        expect(last_response.body).to include('Password')
       end
     end
 
@@ -44,15 +44,15 @@ describe "OmniAuth::Strategies::XAuth" do
         post '/auth/example.org', :username => 'joe', :password => 'passw0rd'
       end
 
-      it 'should redirect to the callback url' do
-        last_response.should be_redirect
-        last_response.headers['Location'].should eq('/auth/example.org/callback')
+      it 'redirects to the callback url' do
+        expect(last_response).to be_redirect
+        expect(last_response.headers['Location']).to eq('/auth/example.org/callback')
       end
 
       it 'sets the xauth credentials to the "omniauth.xauth" session' do
-        session['omniauth.xauth'].should be
-        session['omniauth.xauth']['x_auth_username'].should eq('joe')
-        session['omniauth.xauth']['x_auth_password'].should eq('passw0rd')
+        expect(session['omniauth.xauth']).to be
+        expect(session['omniauth.xauth']['x_auth_username']).to eq('joe')
+        expect(session['omniauth.xauth']['x_auth_password']).to eq('passw0rd')
 
       end
     end
@@ -66,17 +66,17 @@ describe "OmniAuth::Strategies::XAuth" do
         get '/auth/example.org/callback', {}, {'rack.session' => { 'omniauth.xauth' => { 'x_auth_mode' => 'client_auth', 'x_auth_username' => 'username', 'x_auth_password' => 'password' }}}
       end
 
-      it 'should clear "omniauth.xauth" from the session' do
-        session['omniauth.xauth'].should be_nil
+      it 'clears "omniauth.xauth" from the session' do
+        expect(session['omniauth.xauth']).to be_nil
       end
 
-      it 'should exchange the request token for an access token' do
-        last_request.env['omniauth.auth']['provider'].should == 'example.org'
-        last_request.env['omniauth.auth']['extra']['access_token'].should be_kind_of(OAuth::AccessToken)
+      it 'exchanges the request token for an access token' do
+        expect(last_request.env['omniauth.auth']['provider']).to eq('example.org')
+        expect(last_request.env['omniauth.auth']['extra']['access_token']).to be_kind_of(OAuth::AccessToken)
       end
 
-      it 'should call through to the master app' do
-        last_response.body.should == 'true'
+      it 'calls through to the master app' do
+        expect(last_response.body).to eq('true')
       end
     end
 
@@ -87,8 +87,8 @@ describe "OmniAuth::Strategies::XAuth" do
         get '/auth/example.org/callback', {:oauth_verifier => 'dudeman'}, {'rack.session' => { 'omniauth.xauth' => { 'x_auth_mode' => 'client_auth', 'x_auth_username' => 'username', 'x_auth_password' => 'password' }}}
       end
 
-      it 'should call fail! with :service_unavailable' do
-        last_request.env['omniauth.error'].should be_kind_of(::Net::HTTPFatalError)
+      it 'calls fail! with :service_unavailable' do
+        expect(last_request.env['omniauth.error']).to be_kind_of(::Net::HTTPFatalError)
         last_request.env['omniauth.error.type'] = :service_unavailable
       end
     end
@@ -100,8 +100,8 @@ describe "OmniAuth::Strategies::XAuth" do
         get '/auth/example.org/callback', {:oauth_verifier => 'dudeman'}, {'rack.session' => { 'omniauth.xauth' => { 'x_auth_mode' => 'client_auth', 'x_auth_username' => 'username', 'x_auth_password' => 'password' }}}
       end
 
-      it 'should call fail! with :service_unavailable' do
-        last_request.env['omniauth.error'].should be_kind_of(::OpenSSL::SSL::SSLError)
+      it 'calls fail! with :service_unavailable' do
+        expect(last_request.env['omniauth.error']).to be_kind_of(::OpenSSL::SSL::SSLError)
         last_request.env['omniauth.error.type'] = :service_unavailable
       end
     end
@@ -114,8 +114,8 @@ describe "OmniAuth::Strategies::XAuth" do
         get '/auth/example.org/callback', {}, {'rack.session' => { 'omniauth.xauth' => { 'x_auth_mode' => 'client_auth', 'x_auth_username' => 'username', 'x_auth_password' => 'password' }}}
       end
 
-      it 'should call fail! with :service_unavailable' do
-        last_request.env['omniauth.error'].should be_kind_of(::OAuth::Unauthorized)
+      it 'calls fail! with :service_unavailable' do
+        expect(last_request.env['omniauth.error']).to be_kind_of(::OAuth::Unauthorized)
         last_request.env['omniauth.error.type'] = :invalid_credentials
       end
     end
@@ -128,8 +128,8 @@ describe "OmniAuth::Strategies::XAuth" do
       get '/auth/example.org/callback', {:oauth_verifier => 'dudeman'}, {'rack.session' => {}}
     end
 
-    it 'should call fail! with :session_expired' do
-      last_request.env['omniauth.error'].should be_kind_of(::OmniAuth::NoSessionError)
+    it 'calls fail! with :session_expired' do
+      expect(last_request.env['omniauth.error']).to be_kind_of(::OmniAuth::NoSessionError)
       last_request.env['omniauth.error.type'] = :session_expired
     end
   end


### PR DESCRIPTION
MultiJson is referenced even though it’s not specified as a dependency in the gemspec. It’s actually not necessary so I just removed it and cleaned up a few other things while I was in there. Please release after merge. Thanks!
